### PR TITLE
Feature/remove bower and build, add dist to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,14 +9,15 @@ Thumbs.db
 /vendor
 
 # BUILD FILES
-/bower_components/*
-/node_modules/*
-/build/*
+/node_modules
 /yarn-error.log
 /npm-debug.log
 
+# ASSETS
+/web/dist
+
 # VM
-.vagrant/*
+.vagrant
 
 # TEMP
 .cache
@@ -35,6 +36,6 @@ Thumbs.db
 *.sublime-project
 *.tmproj
 *.tmproject
-.vscode/*
+.vscode
 config.codekit3
 prepros-6.config


### PR DESCRIPTION
Removes outdated `bower` and `build` folder references. Adds back `web/dist`
