### PR TITLE
Feature/disable updates from CP

### DIFF
--- a/config/general.php
+++ b/config/general.php
@@ -71,7 +71,10 @@ return [
         'securityKey' => getenv('SECURITY_KEY'),
 
         // This contains info like session, cache, redis, etc.
-        'components' => $components
+        'components' => $components,
+
+        // Disable system and plugin updates in the Control Panel
+        'allowUpdates' => false,
     ],
 
     // Dev environment settings


### PR DESCRIPTION
Disable updates from the Control Panel by default, per Craft founder's advice.

Reference Craft docs at https://docs.craftcms.com/v3/config/config-settings.html#allowupdates
