### PR TITLE
Feature/update browserslist array

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,9 +27,10 @@
     "extends": "odc"
   },
   "browserslist": [
+    "last 1 version",
+    "not dead",
     ">0.25%",
-    "not ie 11",
-    "not op_mini all"
+    "not ie 11"
   ],
   "dependencies": {
     "blendid": "^4.4.3",

--- a/package.json
+++ b/package.json
@@ -27,9 +27,9 @@
     "extends": "odc"
   },
   "browserslist": [
-    "last 3 versions",
-    "> 2%",
-    "ie >= 11"
+    ">0.25%",
+    "not ie 11",
+    "not op_mini all"
   ],
   "dependencies": {
     "blendid": "^4.4.3",


### PR DESCRIPTION
**Description:**
- If applied, this commit will update the base supported browsers in the Craft starter to be more dynamic/evergreen so that tasks that polyfill, transpile, or prefix JS and CSS will only add what's needed as browsers adopt more modern CSS and JS features.
- As it stands, the entry "last 3 versions" will force support in, for example, autoprefixer and babel-preset-env (assuming we end up using that) to support the last three versions of IE ... forever. This can lead to a lot of unnecessary prefixing and transpiling, which leads to larger than necessary CSS and JS files.
- This commit sets a baseline where (order matters) the last 1 version of any browser is supported, or browsers with > .25% usage globally and not IE11. If we need IE11 support, it can then simply act as a toggle.

**Review at:**
- https://browserl.ist/?q=last+1+version%2C+>+0.25%25%2C+not+ie+11
- For reference, here is a link that shows the browsers we are currently supporting with the array as it stands: https://browserl.ist/?q=last+3+versions%2C+%3E+2%25%2C+ie+%3E%3D+11

**Acceptance Criteria:**
- At the moment, I think only autoprefixer is using this configuration, but you can check it by applying CSS features and seeing which prefixes are present in the compiled CSS.
