### PR TITLE
Feature/skip link

### DIFF
--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -1,15 +1,15 @@
 // Variables first
-@import "variables";
+@import 'variables';
 
 // Vendor
-@import "normalize";
-@import "sass-mq/mq";
+@import 'normalize';
+@import 'sass-mq/mq';
 
 // Utils
-@import "util/visually-hidden";
+@import 'util/visually-hidden';
 
 // Base
-@import "base/base";
+@import 'base/base';
 
 // Objects
-@import "objects/skip-link";
+@import 'objects/skip-link';

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -1,10 +1,15 @@
 // Variables first
-@import 'variables';
+@import "variables";
 
 // Vendor
-@import 'normalize';
-@import 'sass-mq/mq';
+@import "normalize";
+@import "sass-mq/mq";
+
+// Utils
+@import "util/visually-hidden";
 
 // Base
-@import 'base/base';
+@import "base/base";
 
+// Objects
+@import "objects/skip-link";

--- a/src/styles/objects/_skip-link.scss
+++ b/src/styles/objects/_skip-link.scss
@@ -1,0 +1,26 @@
+.skip-link {
+  padding: 1em;
+  font-family: inherit;
+  font-size: 16px;
+  font-weight: 700;
+  text-decoration: none;
+  cursor: pointer;
+  border: 3px solid;
+  background-color: #fff;
+
+  &:not(:focus) {
+    @extend %visually-hidden;
+  }
+
+  &:focus {
+    position: absolute;
+    top: 0;
+    left: 0;
+    z-index: 10000;
+  }
+
+  &:focus:not(:hover) {
+    outline: 1px dotted;
+    outline-offset: -0.5em;
+  }
+}

--- a/src/styles/util/_visually-hidden.scss
+++ b/src/styles/util/_visually-hidden.scss
@@ -1,0 +1,11 @@
+%visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: auto;
+  margin: 0;
+  padding: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  clip: rect(0 0 0 0);
+  border: 0;
+}

--- a/templates/_layout.html
+++ b/templates/_layout.html
@@ -23,7 +23,11 @@
 </head>
 
 <body class="{{ bodyClass | default('') }}">
-  {% block content %}{% endblock %}
+  <a class="skip-link" href="#main-content">Skip to content</a>
+
+  <main id="main-content" tabindex="-1" role="main">
+    {% block content %}{% endblock %}
+  </main>
 
   <script src="{{ rev('scripts/app.js') }}"></script>
 </body>


### PR DESCRIPTION
Description:
- Puts a skip link to the top of the `<body>`.
- Wraps Twig `content` block in a `<main>` tag with an ID for the skip link.
- Includes some basic object styles.
- Adds a `visually-hidden` placeholder so it can be extended elsewhere, if needed.