### PR TITLE
Feature/https permanent redirect

### DIFF
--- a/web/.htaccess
+++ b/web/.htaccess
@@ -14,7 +14,7 @@
     RewriteCond %{HTTP:X-Forwarded-Proto} !https [NC]
     RewriteCond %{HTTP_HOST} ^www.example.com [NC,OR]
     RewriteCond %{HTTP_HOST} ^.+\.oneis.us [NC]
-    RewriteRule .* https://%{HTTP_HOST}%{REQUEST_URI} [R=302,L]
+    RewriteRule .* https://%{HTTP_HOST}%{REQUEST_URI} [R=301,L]
 
     # Redirect non-www to www
     # RewriteCond %{HTTP_HOST} ^example.com [NC]


### PR DESCRIPTION
Updates the `http` to `https` redirect from temporary to permanent, a recommendation that came out of an SEO/performance audit on the Oak Street Health site.