### PR TITLE
Feature/removes deprecated seomatic hook

### DIFF
--- a/templates/_partials/head.html
+++ b/templates/_partials/head.html
@@ -1,2 +1,1 @@
 <link rel="stylesheet" href="{{ rev('styles/main.css') }}">
-{% hook 'seomaticRender' %}


### PR DESCRIPTION
Removes the now deprecated SEOmatic hook (`{% hook 'seomaticRender' %}`) which was used to render meta tags. v3 does that automatically now.