### PR TITLE
Removes .htaccess X-Robots-Tag directive

### DIFF
--- a/web/.htaccess
+++ b/web/.htaccess
@@ -25,18 +25,6 @@
     RewriteCond %{REQUEST_URI} ^.+\/$
     RewriteRule ^(.+)\/$ /$1 [L,R=301,NC]
 
-    # Adds noindex, nofollow headers for anything non-production
-    <IfModule mod_headers.c>
-      # For Apache 2.4
-      # <If "req('Host') != 'www.example.com'">
-      #     Header set X-Robots-Tag "noindex, nofollow"
-      # </If>
-
-      # For Apache 2.2
-      SetEnvIfNoCase Host [^(www.example.com)] not_production
-      Header set X-Robots-Tag "noindex,nofollow" ENV=not_production
-    </IfModule>
-
     # Blitz cache rewrite
     # https://putyourlightson.com/craft-plugins/blitz/docs#/?id=server-rewrites
     RewriteCond %{DOCUMENT_ROOT}/cache/blitz/%{HTTP_HOST}/%{REQUEST_URI}/%{QUERY_STRING}/index.html -s


### PR DESCRIPTION
Removes an error-prone `X-Robots-Tag` directive from the `.htaccess`

I'm still investigating why the directive seems to work correctly on older sites, but two recent launches (Hines Securities and CA Ventures) were mistakenly disabling robots from crawling prod because of this. It's possible the regex in `[^(www.example.com)]` is incorrect, but I need to confirm.

The directive really isn't necessary since we use SEOmatic to control robots in dev/staging vs prod environments, this was just an additional fail-safe.