### PR TITLE
Adds dynamic reference to site language in document head.

### DIFF
--- a/templates/_layout.html
+++ b/templates/_layout.html
@@ -14,7 +14,7 @@
 {# Output
 {# --------------------------------------------------------- #}
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" class="no-js">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="{{ craft.app.language }}" class="no-js">
 <head>
   <meta charset="utf-8" />
   <meta http-equiv="x-ua-compatible" content="ie=edge">


### PR DESCRIPTION
Description:
- _If applied, this commit will reflect the actual site language of a given Craft site in the document head.

**Acceptance Criteria:**
- Create a new site with a language other than English and note that the language code changes. e.g., `lang="fr"`