### PR TITLE
Adds core JS and core JS import.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3539,6 +3539,11 @@
         "is-plain-object": "^2.0.1"
       }
     },
+    "core-js": {
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
+      "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA=="
+    },
     "core-js-compat": {
       "version": "3.6.5",
       "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.6.5.tgz",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "not ie 11"
   ],
   "dependencies": {
+    "core-js": "^3.6.5",
     "normalize.css": "^8.0.1",
     "sass-mq": "^5.0.1"
   },

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -1,3 +1,5 @@
+import "core-js";
+
 import App from "./App";
 
 document.documentElement.classList.remove("no-js");


### PR DESCRIPTION
I realized that we weren't importing core-js by default in the project, which meant we weren't getting the polyfilling magic provided by the combination of `babel-preset-env`, core-js, and `useBuiltIns: 'entry'`. For more on that, go here: https://babeljs.io/docs/en/babel-preset-env