### PR TITLE
Added password protection

### DIFF
--- a/templates/_layout.html
+++ b/templates/_layout.html
@@ -20,6 +20,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
 
   {% include '_partials/head' %}
+  {% if craft.app.env != 'production' %}
+    <meta name="robots" content="noindex">
+  {% endif %}
 </head>
 
 <body class="{{ bodyClass | default('') }}">

--- a/web/.htaccess
+++ b/web/.htaccess
@@ -4,6 +4,21 @@
 <IfModule mod_rewrite.c>
     RewriteEngine On
 
+    # Begin Auth stuff
+    # Require a username & password if we're on a *.oneis.us domain
+    SetEnvIfNoCase Host oneis\.us$ require_auth=true
+    
+    AuthUserFile .htpasswd  
+    AuthName "Password Protected"
+    AuthType Basic
+
+    Order Deny,Allow
+    Deny from all
+    Satisfy any
+    Require valid-user
+    Allow from env=!require_auth
+    # End auth stuff
+
     # This sets the environment variable HTTPS to "on"
     # if the request is behind a load balancer which terminates SSL.
     # In PHP, you can access this via $_SERVER['HTTPS']

--- a/web/.htaccess
+++ b/web/.htaccess
@@ -4,7 +4,7 @@
 <IfModule mod_rewrite.c>
     RewriteEngine On
 
-    # Begin Auth stuff
+    # Begin Auth stuff: https://stackoverflow.com/questions/1359472/use-http-auth-only-if-accessing-a-specific-domain
     # Require a username & password if we're on a *.oneis.us domain
     SetEnvIfNoCase Host oneis\.us$ require_auth=true
     

--- a/web/.htpasswd
+++ b/web/.htpasswd
@@ -1,0 +1,1 @@
+onedesign:onKXGj1E/fLy2


### PR DESCRIPTION
Description:
- This adds an htaccess block that forces authentication when a user visits the site on a *oneis.us domain. The login information is in 1Pass labelled `oneis.us Craft Starter Auth htpasswd Login`
- It also adds a conditional to throw a `<meta>` tag to prevent robots from indexing the site if the `env` is not set to `production`
