### PR TITLE
Adds Blitz

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -49,5 +49,8 @@ IMGIX_API_KEY=
 IMGIX_SECURITY_TOKEN=
 IMGIX_SOURCE_DOMAIN=
 
+# Blitz
+ENABLE_TEMPLATE_CACHING=
+
 # (Optional) Set this if you're using redis for sessions/caching
 # REDIS_URL=

--- a/.env.example
+++ b/.env.example
@@ -50,7 +50,7 @@ IMGIX_SECURITY_TOKEN=
 IMGIX_SOURCE_DOMAIN=
 
 # Blitz
-ENABLE_TEMPLATE_CACHING=
+ENABLE_BLITZ_CACHING=
 
 # (Optional) Set this if you're using redis for sessions/caching
 # REDIS_URL=

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,8 @@
     "nystudio107/craft-typogrify": "^1.1",
     "topshelfcraft/environment-label": "^3.1",
     "yiisoft/yii2-redis": "~2.0.0",
-    "nystudio107/craft-seomatic": "^3.3.12"
+    "nystudio107/craft-seomatic": "^3.3.12",
+    "putyourlightson/craft-blitz": "^3.10.0"
   },
   "require-dev": {
     "yiisoft/yii2-shell": "^2.0.3"

--- a/config/blitz.php
+++ b/config/blitz.php
@@ -22,7 +22,7 @@ return [
     'debug' => false,
 
     // Whether static file caching should be enabled.
-    'cachingEnabled' => filter_var(getenv('ENABLE_TEMPLATE_CACHING'), FILTER_VALIDATE_BOOLEAN),
+    'cachingEnabled' => filter_var(getenv('ENABLE_BLITZ_CACHING'), FILTER_VALIDATE_BOOLEAN),
 
     // The URI patterns to include in caching. Set `siteId` to a blank string to indicate all sites.
     'includedUriPatterns' => [

--- a/config/blitz.php
+++ b/config/blitz.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * @copyright Copyright (c) PutYourLightsOn
+ */
+
+/**
+ * Blitz config.php
+ *
+ * This file exists only as a template for the Blitz settings.
+ * It does nothing on its own.
+ *
+ * Don't edit this file, instead copy it to 'craft/config' as 'blitz.php'
+ * and make your changes there to override default settings.
+ *
+ * Once copied to 'craft/config', this file will be multi-environment aware as
+ * well, so you can have different settings groups for each environment, just as
+ * you do for 'general.php'
+ */
+
+return [
+    // Debugging
+    'debug' => false,
+
+    // Whether static file caching should be enabled.
+    'cachingEnabled' => filter_var(getenv('ENABLE_TEMPLATE_CACHING'), FILTER_VALIDATE_BOOLEAN),
+
+    // The URI patterns to include in caching. Set `siteId` to a blank string to indicate all sites.
+    'includedUriPatterns' => [
+       [
+           'siteId' => '',
+           'uriPattern' => '.*',
+       ],
+    ],
+
+    // The URI patterns to exclude from caching (overrides any matching patterns to include). Set `siteId` to a blank string to indicate all sites.
+    // 'excludedUriPatterns' => [
+    //     [
+    //         'siteId' => '',
+    //         'uriPattern' => '/example/path',
+    //     ],
+    // ],
+
+    // Whether the cache should automatically be cleared when elements are updated.
+    'clearCacheAutomatically' => true,
+
+    // Whether the cache should automatically be warmed after clearing.
+    'warmCacheAutomatically' => false,
+
+    // The warmer settings.
+    'cacheWarmerSettings' => ['concurrency' => 3],
+
+    // Whether the cache should automatically be refreshed after a global set is updated.
+    'refreshCacheAutomaticallyForGlobals' => true,
+
+    // Whether URLs with query strings should cached and how.
+    // 0: Do not cache URLs with query strings
+    // 1: Cache URLs with query strings as unique pages
+    // 2: Cache URLs with query strings as the same page
+    'queryStringCaching' => 0,
+];

--- a/config/blitz.php
+++ b/config/blitz.php
@@ -17,12 +17,14 @@
  * you do for 'general.php'
  */
 
+use craft\helpers\App;
+
 return [
     // Debugging
     'debug' => false,
 
     // Whether static file caching should be enabled.
-    'cachingEnabled' => filter_var(getenv('ENABLE_BLITZ_CACHING'), FILTER_VALIDATE_BOOLEAN),
+    'cachingEnabled' => App::env('ENVIRONMENT') !== 'dev' || filter_var(App::env('ENABLE_BLITZ_CACHING'), FILTER_VALIDATE_BOOLEAN),
 
     // The URI patterns to include in caching. Set `siteId` to a blank string to indicate all sites.
     'includedUriPatterns' => [
@@ -52,9 +54,23 @@ return [
     // Whether the cache should automatically be refreshed after a global set is updated.
     'refreshCacheAutomaticallyForGlobals' => true,
 
+    // The integrations to initialise.
+    'integrations' => [
+        // Uncomment below if using Feed Me
+        // 'putyourlightson\blitz\drivers\integrations\FeedMeIntegration',
+        'putyourlightson\blitz\drivers\integrations\SeomaticIntegration',
+    ],
+
     // Whether URLs with query strings should cached and how.
     // 0: Do not cache URLs with query strings
     // 1: Cache URLs with query strings as unique pages
     // 2: Cache URLs with query strings as the same page
     'queryStringCaching' => 0,
+
+    // The query string parameters to exclude when determining if and how a page should be cached (regular expressions may be used).
+    'excludedQueryStringParams' => [
+        'utm_*',
+        'gclid',
+        'fbclid',
+    ],
 ];


### PR DESCRIPTION
Adds Blitz and related config file.

Seems like we use Blitz often enough to bake it into our Starter, but ultimately I'll defer to the team. If we do decide to add Blitz, I highly recommend using the included config, which sets `warmCacheAutomatically` to `false`. I've been burned many times in the retainer world by process-intensive cache warming that brings the site to a halt.