### PR TITLE
Adds twig autocomplete

### DIFF
--- a/app/composer.json
+++ b/app/composer.json
@@ -28,7 +28,8 @@
     "topshelfcraft/environment-label": "^3.1",
     "yiisoft/yii2-redis": "~2.0.0",
     "nystudio107/craft-seomatic": "^3.3.12",
-    "putyourlightson/craft-blitz": "^3.10.0"
+    "putyourlightson/craft-blitz": "^3.10.0",
+    "putyourlightson/craft-autocomplete": "^1.0"
   },
   "require-dev": {
     "yiisoft/yii2-shell": "^2.0.3"


### PR DESCRIPTION
Adds the [Autocomplete](https://github.com/putyourlightson/craft-autocomplete) package by Put Your Lights on. If you're using IDEA / PHPStorm this will give you autocomplete of the `craft` variable in your twig templates (as long as you have the [Symfony plugin](https://plugins.jetbrains.com/plugin/7219-symfony-plugin) installed)


Closes #61 
