### PR TITLE
Remove redis package from composer.json

### DIFF
--- a/app/composer.json
+++ b/app/composer.json
@@ -26,7 +26,6 @@
     "craftcms/aws-s3": "^1.0",
     "nystudio107/craft-typogrify": "^1.1",
     "topshelfcraft/environment-label": "^3.1",
-    "yiisoft/yii2-redis": "~2.0.0",
     "nystudio107/craft-seomatic": "^3.3.12",
     "putyourlightson/craft-blitz": "^3.10.0",
     "putyourlightson/craft-autocomplete": "^1.0"


### PR DESCRIPTION
We rarely use redis on our projects, definitely not enough to need it in the starter.