### PR TITLE
Remove CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-* @brandonkelly


### PR DESCRIPTION
CODEOWNERS is used to define who is responsible for the code in a repository, and that account is automatically requested for a review when someone opens a PR. That's outside the scope of this template repo (if not virtually all of our projects), so I say we remove this.