### PR TITLE
Updated node in ddev

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -14,7 +14,9 @@ composer_root: app
 composer_version: '2'
 web_environment:
   - CRAFT_CMD_ROOT=./app
-nodejs_version: '20'
+hooks:
+  post-start:
+    - exec: 'nvm install 20 && nvm use 20'
 # Key features of DDEV's config.yaml:
 
 # name: <projectname> # Name of the project, automatically provides


### PR DESCRIPTION
```
Failed to get project(s): unsupported system Node.js version: '20'; for the system Node.js version ddev only supports [14 16 18]. However, you can use 'ddev nvm install' at runtime to use any supported version
```

DDev doesn't support node 20 out of the box, so you need to add this post-start hook to install and use it.
https://github.com/ddev/ddev/issues/4250