### PR TITLE
Fix filename of example env

### DIFF
--- a/app/composer.json
+++ b/app/composer.json
@@ -36,7 +36,7 @@
   },
   "scripts": {
     "post-root-package-install": [
-      "@php -r \"file_exists('.env') || copy('.env.example.dev', '.env');\""
+      "@php -r \"file_exists('.env') || copy('.env.example', '.env');\""
     ]
   }
 }


### PR DESCRIPTION
We consolidated `.env.example.*` into a single `.env.example` file.