### PR TITLE
Feature / Formie Config

### DIFF
--- a/app/config/formie.php
+++ b/app/config/formie.php
@@ -1,0 +1,8 @@
+<?php
+
+return [
+    '*' => [
+        // Sends email notifications as a form is submitted rather than being added to Craft's queue
+        'useQueueForNotifications' => false,
+    ]
+];


### PR DESCRIPTION
Adds a Formie config file to disable sending email notifications via the craft queue by default, as discussed in our last L10: https://www.notion.so/onedesigncompany/Formie-Email-notifications-1ec5d56bd8ad807a9cbffaa2efaff40d?pvs=4
