### PR TITLE
DDEV: Disable Settings Management

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -15,6 +15,7 @@ composer_version: "2"
 web_environment:
     - CRAFT_CMD_ROOT=./app
 nodejs_version: "20"
+disable_settings_management: true
 
 # Key features of DDEV's config.yaml:
 


### PR DESCRIPTION
By default, DDEV tries to automatically configure the database connection via a `.ddev/.env.web` file. This PR disables this so we can continue to manage our environment variables in our existing `app/.env` file.

https://ddev.readthedocs.io/en/stable/users/quickstart/#craft-cms

https://ddev.readthedocs.io/en/stable/users/configuration/config/#disable_settings_management